### PR TITLE
feat: new rountripper func

### DIFF
--- a/client.go
+++ b/client.go
@@ -36,9 +36,7 @@ func NewCustomClient(client *http.Client, opts ...Option) *http.Client {
 		panic("client must not be nil")
 	}
 
-	retryRoundtripper := NewRoundtripper(client.Transport, opts...)
-
-	client.Transport = retryRoundtripper
+	client.Transport = NewRoundtripper(client.Transport, opts...)
 
 	return client
 }

--- a/client.go
+++ b/client.go
@@ -5,24 +5,20 @@ import (
 	"net/http"
 )
 
-const (
-	defaultMaxRetryCount = 5
-)
-
 // NewDefaultClient returns a default http client with retry functionality wrapped around the Roundtripper (client.Transport).
 //
 // You should not replace the client.Transport field, otherwise you will lose the retry functionality.
 //
 // If you need to set / change the original client.Transport field you have two options:
 //
-// 1. create your own http client and use NewCustomClient() function to enrich the client with retry functionality.
-//   client := &http.Client{}
-//   client.Transport = &http.Transport{ ... }
-//   retryClient := httpretry.NewCustomClient(client)
-// 2. use one of the helper functions (e.g. httpretry.ModifyOriginalTransport(retryClient)) to retrieve and change the Transport.
-//   retryClient := httpretry.NewDefaultClient()
-//   err := httpretry.ModifyOriginalTransport(retryClient, func(t *http.Transport){t.TLSHandshakeTimeout = 5 * time.Second})
-//   if err != nil { ... } // will be nil if embedded Roundtripper was not of type http.Transport
+//  1. create your own http client and use NewCustomClient() function to enrich the client with retry functionality.
+//     client := &http.Client{}
+//     client.Transport = &http.Transport{ ... }
+//     retryClient := httpretry.NewCustomClient(client)
+//  2. use one of the helper functions (e.g. httpretry.ModifyOriginalTransport(retryClient)) to retrieve and change the Transport.
+//     retryClient := httpretry.NewDefaultClient()
+//     err := httpretry.ModifyOriginalTransport(retryClient, func(t *http.Transport){t.TLSHandshakeTimeout = 5 * time.Second})
+//     if err != nil { ... } // will be nil if embedded Roundtripper was not of type http.Transport
 func NewDefaultClient(opts ...Option) *http.Client {
 	return NewCustomClient(&http.Client{}, opts...)
 }
@@ -33,30 +29,14 @@ func NewDefaultClient(opts ...Option) *http.Client {
 //
 // If you need to change the original client.Transport field you may use the helper functions:
 //
-//   err := httpretry.ModifyTransport(retryClient, func(t *http.Transport){t.TLSHandshakeTimeout = 5 * time.Second})
-//   if err != nil { ... } // will be nil if embedded Roundtripper was not of type http.Transport
+//	err := httpretry.ModifyTransport(retryClient, func(t *http.Transport){t.TLSHandshakeTimeout = 5 * time.Second})
+//	if err != nil { ... } // will be nil if embedded Roundtripper was not of type http.Transport
 func NewCustomClient(client *http.Client, opts ...Option) *http.Client {
 	if client == nil {
 		panic("client must not be nil")
 	}
 
-	nextRoundtripper := client.Transport
-	if nextRoundtripper == nil {
-		nextRoundtripper = http.DefaultTransport
-	}
-
-	// set defaults
-	retryRoundtripper := &RetryRoundtripper{
-		Next:             nextRoundtripper,
-		MaxRetryCount:    defaultMaxRetryCount,
-		ShouldRetry:      defaultRetryPolicy,
-		CalculateBackoff: defaultBackoffPolicy,
-	}
-
-	// overwrite defaults with user provided configuration
-	for _, o := range opts {
-		o(retryRoundtripper)
-	}
+	retryRoundtripper := NewRoundtripper(client.Transport, opts...)
 
 	client.Transport = retryRoundtripper
 

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -20,6 +20,8 @@ type RetryRoundtripper struct {
 	CalculateBackoff BackoffPolicy
 }
 
+// NewRoundtripper creates a new RetryRoundtripper with the provided options.
+// If no next [net/http.RoundTripper] is provided, the default [net/http.DefaultTransport] will be used.
 func NewRoundtripper(next http.RoundTripper, opts ...Option) *RetryRoundtripper {
 	if next == nil {
 		next = http.DefaultTransport

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -7,6 +7,10 @@ import (
 	"time"
 )
 
+const (
+	defaultMaxRetryCount = 5
+)
+
 // RetryRoundtripper is the roundtripper that will wrap around the actual http.Transport roundtripper
 // to enrich the http client with retry functionality.
 type RetryRoundtripper struct {
@@ -14,6 +18,25 @@ type RetryRoundtripper struct {
 	MaxRetryCount    int
 	ShouldRetry      RetryPolicy
 	CalculateBackoff BackoffPolicy
+}
+
+func NewRoundtripper(next http.RoundTripper, opts ...Option) *RetryRoundtripper {
+	if next == nil {
+		next = http.DefaultTransport
+	}
+
+	roundTripper := &RetryRoundtripper{
+		Next:             next,
+		MaxRetryCount:    defaultMaxRetryCount,
+		ShouldRetry:      defaultRetryPolicy,
+		CalculateBackoff: defaultBackoffPolicy,
+	}
+
+	for _, o := range opts {
+		o(roundTripper)
+	}
+
+	return roundTripper
 }
 
 // RoundTrip implements the actual roundtripper interface (http.RoundTripper).


### PR DESCRIPTION
Exposing an option to create a RetryRoundTripper with the default configuration. This feature is particularly useful for developers who need to control the transport composition more effectively.